### PR TITLE
Ops: show anomaly resolution history

### DIFF
--- a/src/services/quantReconcile.ts
+++ b/src/services/quantReconcile.ts
@@ -28,6 +28,15 @@ export type TriggerReconcileResponse = {
   anomalies: ReconcileAnomaly[];
 };
 
+export type ReconcileAnomalyAction = {
+  id: string;
+  anomaly_id: string;
+  action_type: string;
+  actor: string;
+  note?: string | null;
+  created_at_utc: string;
+};
+
 async function apiGet<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, { cache: 'no-store' });
   const json = await res.json().catch(() => null);
@@ -74,4 +83,6 @@ export const quantReconcile = {
     params.set('resolved_by', resolvedBy);
     return apiPost<{ resolved: boolean; id: string }>(`/api/reconcile/anomalies/${id}/resolve?${params.toString()}`);
   },
+
+  anomalyActions: (id: string) => apiGet<{ actions: ReconcileAnomalyAction[] }>(`/api/reconcile/anomalies/${id}/actions`),
 };


### PR DESCRIPTION
Adds a History section to the anomaly Details dialog using the new backend endpoint:
- GET /api/reconcile/anomalies/{id}/actions

Implementation:
- src/services/quantReconcile.ts: adds anomalyActions() + action type
- ReconcileOrdersPanel: loads and renders action history inside the details dialog

Build verified with next build.