### PR TITLE
P1-17: Ops UI tables for intents/broker orders/fills

### DIFF
--- a/src/components/dashboard/ReconcileOrdersPanel.tsx
+++ b/src/components/dashboard/ReconcileOrdersPanel.tsx
@@ -19,6 +19,22 @@ function severityBadgeVariant(sev?: string) {
   return { variant: 'outline' as const, label: s || '?' };
 }
 
+function formatEt(ts?: string | null) {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(d);
+}
+
 function AnomalyHistory({
   anomaly,
   loadActions,
@@ -217,8 +233,8 @@ export function ReconcileOrdersPanel() {
               <div className="font-semibold">{status?.pending_groups ?? '—'}</div>
             </div>
             <div>
-              <div className="text-muted-foreground">Last successful entry reconcile</div>
-              <div className="font-semibold">{status?.last_successful_reconcile_at ?? '—'}</div>
+              <div className="text-muted-foreground">Last successful entry reconcile (ET)</div>
+              <div className="font-semibold">{formatEt(status?.last_successful_reconcile_at ?? null)}</div>
             </div>
             <div>
               <div className="text-muted-foreground">Open anomalies</div>
@@ -275,7 +291,7 @@ export function ReconcileOrdersPanel() {
                       <TableCell className="font-medium">{a.type}</TableCell>
                       <TableCell>{a.broker || '—'}</TableCell>
                       <TableCell className="font-mono text-xs">{a.broker_order_id || '—'}</TableCell>
-                      <TableCell className="text-xs">{a.last_seen_at || '—'}</TableCell>
+                      <TableCell className="text-xs">{formatEt(a.last_seen_at || null)}</TableCell>
                       <TableCell className="text-right">
                         <div className="flex justify-end gap-2">
                           <Button
@@ -359,7 +375,7 @@ export function ReconcileOrdersPanel() {
                       if (x.trade_group_id) setSelectedTradeGroupId(x.trade_group_id);
                     }}
                   >
-                    <TableCell className="text-xs">{x.created_at || '—'}</TableCell>
+                    <TableCell className="text-xs">{formatEt(x.created_at || null)}</TableCell>
                     <TableCell>{x.broker}</TableCell>
                     <TableCell className="font-mono text-xs">{x.id.slice(0, 8)}</TableCell>
                     <TableCell className="font-mono text-xs">{x.trade_group_id?.slice(0, 8) || '—'}</TableCell>
@@ -402,7 +418,7 @@ export function ReconcileOrdersPanel() {
                     <TableCell className="font-mono text-xs">{b.state}</TableCell>
                     <TableCell className="font-mono text-xs">{b.broker_order_id}</TableCell>
                     <TableCell className="font-mono text-xs">{b.intent_id.slice(0, 8)}</TableCell>
-                    <TableCell className="text-xs">{b.last_seen_at_utc || '—'}</TableCell>
+                    <TableCell className="text-xs">{formatEt(b.last_seen_at_utc || null)}</TableCell>
                   </TableRow>
                 ))
               )}
@@ -448,7 +464,7 @@ export function ReconcileOrdersPanel() {
               ) : (
                 fills.map((f, i) => (
                   <TableRow key={`${f.order_id || 'o'}-${i}`}>
-                    <TableCell className="text-xs">{f.fill_time || '—'}</TableCell>
+                    <TableCell className="text-xs">{formatEt(f.fill_time || null)}</TableCell>
                     <TableCell>{f.broker || '—'}</TableCell>
                     <TableCell className="font-mono text-xs">{f.order_id || '—'}</TableCell>
                     <TableCell className="font-mono text-xs">{f.symbol || '—'}</TableCell>

--- a/src/components/dashboard/ReconcileOrdersPanel.tsx
+++ b/src/components/dashboard/ReconcileOrdersPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { quantReconcile, ReconcileAnomaly, ReconcileAnomalyAction, ReconcileStatus } from '@/services/quantReconcile';
+import { quantOps, OrderIntent, BrokerOrder, FillEvent } from '@/services/quantOps';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -82,18 +83,34 @@ export function ReconcileOrdersPanel() {
   const [error, setError] = useState<string | null>(null);
   const [lastTrigger, setLastTrigger] = useState<any>(null);
 
+  const [orderIntents, setOrderIntents] = useState<OrderIntent[]>([]);
+  const [brokerOrders, setBrokerOrders] = useState<BrokerOrder[]>([]);
+  const [fills, setFills] = useState<FillEvent[]>([]);
+  const [selectedIntentId, setSelectedIntentId] = useState<string | null>(null);
+  const [selectedTradeGroupId, setSelectedTradeGroupId] = useState<string | null>(null);
+
   const p0Count = useMemo(() => (status?.anomalies_by_severity?.P0 ?? 0), [status]);
 
   async function refresh() {
     setLoading(true);
     setError(null);
     try {
-      const [st, an] = await Promise.all([
+      const [st, an, intents, bords] = await Promise.all([
         quantReconcile.status(),
         quantReconcile.anomalies({ open_only: true }),
+        quantOps.orderIntents({ limit: 100 }),
+        quantOps.brokerOrders({ limit: 200 }),
       ]);
       setStatus(st);
       setAnomalies(an.anomalies || []);
+      setOrderIntents(intents.order_intents || []);
+      setBrokerOrders(bords.broker_orders || []);
+
+      // Refresh fills if a trade_group_id is selected
+      if (selectedTradeGroupId) {
+        const f = await quantOps.fills(selectedTradeGroupId, { limit: 1000 });
+        setFills(f.fill_events || []);
+      }
     } catch (e: any) {
       setError(e?.message || 'Failed to load reconcile data');
     } finally {
@@ -136,6 +153,35 @@ export function ReconcileOrdersPanel() {
     return () => clearInterval(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!selectedTradeGroupId) {
+      setFills([]);
+      return;
+    }
+    let cancelled = false;
+    quantOps
+      .fills(selectedTradeGroupId, { limit: 1000 })
+      .then((res) => {
+        if (!cancelled) setFills(res.fill_events || []);
+      })
+      .catch((e: any) => {
+        if (!cancelled) setError(e?.message || 'Failed to load fills');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTradeGroupId]);
+
+  const selectedIntent = useMemo(
+    () => (selectedIntentId ? orderIntents.find((x) => x.id === selectedIntentId) : null),
+    [selectedIntentId, orderIntents],
+  );
+
+  const brokerOrdersForSelectedIntent = useMemo(() => {
+    if (!selectedIntentId) return brokerOrders;
+    return brokerOrders.filter((b) => b.intent_id === selectedIntentId);
+  }, [brokerOrders, selectedIntentId]);
 
   return (
     <div className="space-y-4">
@@ -232,6 +278,20 @@ export function ReconcileOrdersPanel() {
                       <TableCell className="text-xs">{a.last_seen_at || '—'}</TableCell>
                       <TableCell className="text-right">
                         <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              if (a.intent_id) {
+                                setSelectedIntentId(a.intent_id);
+                                const intent = orderIntents.find((x) => x.id === a.intent_id);
+                                if (intent?.trade_group_id) setSelectedTradeGroupId(intent.trade_group_id);
+                              }
+                            }}
+                          >
+                            Drilldown
+                          </Button>
+
                           <Dialog>
                             <DialogTrigger asChild>
                               <Button variant="outline" size="sm">Details</Button>
@@ -260,6 +320,144 @@ export function ReconcileOrdersPanel() {
                     </TableRow>
                   );
                 })
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>OrderIntents (recent)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Created</TableHead>
+                <TableHead>Broker</TableHead>
+                <TableHead>Intent</TableHead>
+                <TableHead>Trade group</TableHead>
+                <TableHead>engine_sha</TableHead>
+                <TableHead>config_hash</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {orderIntents.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-muted-foreground">
+                    No order intents.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                orderIntents.slice(0, 50).map((x) => (
+                  <TableRow
+                    key={x.id}
+                    className={selectedIntentId === x.id ? 'bg-muted/50' : ''}
+                    onClick={() => {
+                      setSelectedIntentId(x.id);
+                      if (x.trade_group_id) setSelectedTradeGroupId(x.trade_group_id);
+                    }}
+                  >
+                    <TableCell className="text-xs">{x.created_at || '—'}</TableCell>
+                    <TableCell>{x.broker}</TableCell>
+                    <TableCell className="font-mono text-xs">{x.id.slice(0, 8)}</TableCell>
+                    <TableCell className="font-mono text-xs">{x.trade_group_id?.slice(0, 8) || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{x.engine_sha?.slice(0, 8) || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{x.config_hash?.slice(0, 8) || '—'}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>BrokerOrders {selectedIntentId ? '(filtered by intent)' : '(recent)'}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Broker</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>broker_order_id</TableHead>
+                <TableHead>Intent</TableHead>
+                <TableHead>Last seen</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(brokerOrdersForSelectedIntent || []).length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-muted-foreground">
+                    No broker orders.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                brokerOrdersForSelectedIntent.slice(0, 100).map((b) => (
+                  <TableRow key={b.id}>
+                    <TableCell>{b.broker}</TableCell>
+                    <TableCell className="font-mono text-xs">{b.state}</TableCell>
+                    <TableCell className="font-mono text-xs">{b.broker_order_id}</TableCell>
+                    <TableCell className="font-mono text-xs">{b.intent_id.slice(0, 8)}</TableCell>
+                    <TableCell className="text-xs">{b.last_seen_at_utc || '—'}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>Fill ledger {selectedTradeGroupId ? `(trade_group=${selectedTradeGroupId.slice(0, 8)})` : ''}</CardTitle>
+          <div className="text-xs text-muted-foreground">
+            {selectedTradeGroupId ? 'click an OrderIntent to load fills' : 'select an OrderIntent'}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Fill time</TableHead>
+                <TableHead>Broker</TableHead>
+                <TableHead>Order</TableHead>
+                <TableHead>Symbol</TableHead>
+                <TableHead>Side</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead className="text-right">Qty</TableHead>
+                <TableHead className="text-right">Price</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {!selectedTradeGroupId ? (
+                <TableRow>
+                  <TableCell colSpan={8} className="text-muted-foreground">
+                    Select an OrderIntent (with trade_group_id) to view fills.
+                  </TableCell>
+                </TableRow>
+              ) : fills.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={8} className="text-muted-foreground">
+                    No fill events yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                fills.map((f, i) => (
+                  <TableRow key={`${f.order_id || 'o'}-${i}`}>
+                    <TableCell className="text-xs">{f.fill_time || '—'}</TableCell>
+                    <TableCell>{f.broker || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{f.order_id || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{f.symbol || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{f.side || '—'}</TableCell>
+                    <TableCell className="font-mono text-xs">{f.event_type || '—'}</TableCell>
+                    <TableCell className="text-right font-mono text-xs">{String(f.filled_qty ?? '—')}</TableCell>
+                    <TableCell className="text-right font-mono text-xs">{String(f.fill_price ?? '—')}</TableCell>
+                  </TableRow>
+                ))
               )}
             </TableBody>
           </Table>

--- a/src/services/quantOps.ts
+++ b/src/services/quantOps.ts
@@ -1,0 +1,78 @@
+import { API_BASE } from './apiBase';
+
+export type OrderIntent = {
+  id: string;
+  broker: string;
+  strategy_id?: string | null;
+  trade_group_id?: string | null;
+  idempotency_key?: string | null;
+  engine_sha?: string | null;
+  config_hash?: string | null;
+  created_at?: string | null;
+  request_json?: any;
+  config_json?: any;
+};
+
+export type BrokerOrder = {
+  id: string;
+  intent_id: string;
+  broker: string;
+  broker_order_id: string;
+  state: string;
+  submitted_at_utc?: string | null;
+  ack_at_utc?: string | null;
+  last_seen_at_utc?: string | null;
+  created_at?: string | null;
+  raw?: any;
+};
+
+export type FillEvent = {
+  id?: string;
+  trade_group_id?: string | null;
+  broker?: string | null;
+  order_id?: string | null;
+  symbol?: string | null;
+  underlying?: string | null;
+  side?: string | null;
+  event_type?: string | null;
+  filled_qty?: number | string | null;
+  fill_price?: number | string | null;
+  fill_time?: string | null;
+  created_at?: string | null;
+  raw?: any;
+};
+
+async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, { cache: 'no-store' });
+  const json = await res.json().catch(() => null);
+  if (!res.ok || !json?.success) {
+    const msg = json?.error || `Request failed: ${res.status}`;
+    throw new Error(msg);
+  }
+  return json.data as T;
+}
+
+export const quantOps = {
+  orderIntents: (opts?: { broker?: string; limit?: number }) => {
+    const params = new URLSearchParams();
+    if (opts?.broker) params.set('broker', opts.broker);
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    return apiGet<{ order_intents: OrderIntent[] }>(`/api/ops/order-intents?${params.toString()}`);
+  },
+
+  brokerOrders: (opts?: { broker?: string; state?: string; intent_id?: string; limit?: number }) => {
+    const params = new URLSearchParams();
+    if (opts?.broker) params.set('broker', opts.broker);
+    if (opts?.state) params.set('state', opts.state);
+    if (opts?.intent_id) params.set('intent_id', opts.intent_id);
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    return apiGet<{ broker_orders: BrokerOrder[] }>(`/api/ops/broker-orders?${params.toString()}`);
+  },
+
+  fills: (trade_group_id: string, opts?: { limit?: number }) => {
+    const params = new URLSearchParams();
+    params.set('trade_group_id', trade_group_id);
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    return apiGet<{ fill_events: FillEvent[] }>(`/api/ops/fills?${params.toString()}`);
+  },
+};


### PR DESCRIPTION
Closes #9.

Adds Phase-1 Ops artifacts to the dashboard "Reconcile / Orders" tab.

Features:
- Recent OrderIntents table
  - shows broker, trade_group_id, engine_sha, config_hash
  - click row selects intent and loads fill ledger by trade_group_id
- BrokerOrders table
  - shows broker/state/broker_order_id/intent_id/last_seen
  - auto-filters by selected intent when present
- Fill ledger view
  - loads from `/api/ops/fills?trade_group_id=...`
  - shows symbol/side/type/qty/price
- Anomaly drilldown button
  - selects intent_id from anomaly and auto-selects its trade_group_id when present

Implementation:
- New service: src/services/quantOps.ts (calls ops endpoints)
- Updates: src/components/dashboard/ReconcileOrdersPanel.tsx

Build:
- `npm run build` passes locally.
